### PR TITLE
fix: compilation errors

### DIFF
--- a/PIC24_dsPIC33/CO_driver.c
+++ b/PIC24_dsPIC33/CO_driver.c
@@ -368,11 +368,11 @@ CO_ReturnError_t CO_CANrxBufferInit(
         uint16_t                mask,
         bool_t                  rtr,
         void                   *object,
-        void                  (*CANrx_callback)(void *object, void *message))
+        void                  (*pFunct)(void *object, const CO_CANrxMsg_t *message))
 {
     CO_ReturnError_t ret = CO_ERROR_NO;
 
-    if((CANmodule!=NULL) && (object!=NULL) && (CANrx_callback!=NULL) && (index < CANmodule->rxSize)){
+    if((CANmodule!=NULL) && (object!=NULL) && (pFunct!=NULL) && (index < CANmodule->rxSize)){
         /* buffer, which will be configured */
         CO_CANrx_t *buffer = &CANmodule->rxArray[index];
         uint16_t RXF, RXM;
@@ -380,7 +380,7 @@ CO_ReturnError_t CO_CANrxBufferInit(
 
         /* Configure object variables */
         buffer->object = object;
-        buffer->CANrx_callback = CANrx_callback;
+        buffer->CANrx_callback = pFunct;
 
 
         /* CAN identifier and CAN mask, bit aligned with CAN module registers (in DMA RAM) */

--- a/PIC24_dsPIC33/CO_driver.c
+++ b/PIC24_dsPIC33/CO_driver.c
@@ -199,6 +199,8 @@ CO_ReturnError_t CO_CANmodule_init(
 
     for(i=0U; i<rxSize; i++){
         rxArray[i].ident = 0U;
+        rxArray[i].mask = (uint16_t)0xFFFFFFFFU;
+        rxArray[i].object = NULL;
         rxArray[i].CANrx_callback = NULL;
     }
     for(i=0U; i<txSize; i++){

--- a/PIC24_dsPIC33/CO_driver_target.h
+++ b/PIC24_dsPIC33/CO_driver_target.h
@@ -57,6 +57,7 @@ typedef long double             float64_t;
 typedef char                    char_t;
 typedef unsigned char           oChar_t;
 typedef unsigned char           domain_t;
+typedef unsigned int            uintptr_t;
 
 
 /* CAN message buffer sizes for CAN module 1 and 2. Valid values
@@ -143,7 +144,7 @@ typedef struct {
     uint16_t ident;
     uint16_t mask;
     void *object;
-    void (*CANrx_callback)(void *object, void *message);
+    void (*CANrx_callback)(void *object, const CO_CANrxMsg_t *message);
 } CO_CANrx_t;
 
 /* Transmit message object */
@@ -192,10 +193,10 @@ typedef struct {
 #define CO_ENABLE_INTERRUPTS()   asm volatile ("disi #0x0000")
 
 /* Synchronization between CAN receive and message processing threads. */
-#define CO_MemoryBarrier()
-#define CO_CANrxNew_READ(rxNew) ((int *)rxNew)
-#define CO_CANrxNew_SET(rxNew) {CO_MemoryBarrier(); rxNew = (void*)1L;}
-#define CO_CANrxNew_CLEAR(rxNew) {CO_MemoryBarrier(); rxNew = (void*)0L;}
+#define CANrxMemoryBarrier()
+#define IS_CANrxNew(rxNew) ((uintptr_t)rxNew)
+#define SET_CANrxNew(rxNew) {CANrxMemoryBarrier(); rxNew = (void*)1L;}
+#define CLEAR_CANrxNew(rxNew) {CANrxMemoryBarrier(); rxNew = (void*)0L;}
 
 
 /* CAN bit rates


### PR DESCRIPTION
Hi Janez,

I had to modify the driver code to get this working with current CANOpenNode.

I also had to comment in CO_driver.h : 
`uint16_t CO_CANrxMsg_readIdent(const CO_CANrxMsg_t *rxMsg);` 

or I get a conflict with in CO_driver_target.h : 
`#define CO_CANrxMsg_readIdent(msg) ((((uint16_t)(((CO_CANrxMsg_t *)(msg))->ident))>>2)&0x7FF)`

I did not find the way to fix this without commenting the line.

This is the error code : 

> In file included from CANopenPIC/CANopenNode/CANopen.h:67:0,
>                  from main.c:23:
> CANopenPIC/CANopenNode/CO_driver.h:174:10: error: expected declaration specifiers or '...' before '(' token
> CANopenPIC/CANopenNode/CO_driver.h:174:10: error: expected ')' before '>>' token
> CANopenPIC/CANopenNode/CO_driver.h:174:10: error: expected ')' before '&' token

That may be related with the order that files are compiled ?